### PR TITLE
Remove default repo_name value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,6 @@ variable "char_delimiter" {
 
 variable "repo_name" {
   description = "The name of the CodeCommit repository (e.g. new-repo)."
-  default     = ""
 }
 
 variable "repo_default_branch" {


### PR DESCRIPTION
When repo_name is empty, some names are invalid.

e.g.
`name           = "${var.repo_name}-package"`
`name           = "${var.repo_name}-test"`